### PR TITLE
Add prestart tasks waiting for dependent services.

### DIFF
--- a/test/hive-connect.hcl
+++ b/test/hive-connect.hcl
@@ -24,6 +24,28 @@ job "hive" {
       }
     }
 
+    task "waitfor-hive-metastore" {
+      lifecycle {
+        hook = "prestart"
+      }
+      driver = "docker"
+      resources {
+        memory = 32
+      }
+      config {
+        image = "consul:latest"
+        entrypoint = ["/bin/sh"]
+        args = ["-c", "jq </local/service.json -e '.[].Status|select(. == \"passing\")'"]
+        volumes = ["tmp/service.json:/local/service.json" ]
+      }
+      template {
+        destination = "tmp/service.json"
+        data = <<EOH
+          {{- service "hive-metastore" | toJSON -}}
+        EOH
+      }
+    }
+
     service {
       name = "hive-server"
       port = 10000
@@ -162,6 +184,28 @@ EOH
 
     network {
       mode = "bridge"
+    }
+
+    task "waitfor-hive-database" {
+      lifecycle {
+        hook = "prestart"
+      }
+      driver = "docker"
+      resources {
+        memory = 32
+      }
+      config {
+        image = "consul:latest"
+        entrypoint = ["/bin/sh"]
+        args = ["-c", "jq </local/service.json -e '.[].Status|select(. == \"passing\")'"]
+        volumes = ["tmp/service.json:/local/service.json" ]
+      }
+      template {
+        destination = "tmp/service.json"
+        data = <<EOH
+          {{- service "hive-database" | toJSON -}}
+        EOH
+      }
     }
 
     task "waitfor-minio-has-required-buckets" {

--- a/test/hive-connect.hcl
+++ b/test/hive-connect.hcl
@@ -25,6 +25,10 @@ job "hive" {
     }
 
     task "waitfor-hive-metastore" {
+        restart {
+            attempts = 10
+            delay    = "15s"
+        }
       lifecycle {
         hook = "prestart"
       }

--- a/test/hive-connect.hcl
+++ b/test/hive-connect.hcl
@@ -191,6 +191,10 @@ EOH
     }
 
     task "waitfor-hive-database" {
+        restart {
+            attempts = 5
+            delay    = "15s"
+        }    
       lifecycle {
         hook = "prestart"
       }


### PR DESCRIPTION
closes https://github.com/fredrikhgrelland/data-mesh/issues/33

This PR adds two consul-checks as prestart tasks. It utilize the consul docker image ( but it really could be any image containing jq ). and it works as follows:

```
task "waitfor-hive-metastore" {
      lifecycle {
        hook = "prestart"
      }
      driver = "docker"
      resources {
        memory = 32  #reduced memory footprint
      }

      template { 
        destination = "tmp/service.json"
        # Render a template containing information on service as a json file
        data = <<EOH
          {{- service "hive-metastore" | toJSON -}}
        EOH
      }
      config {
        image = "consul:latest"  #Consul image contains jq.
        entrypoint = ["/bin/sh"] # Run a shell
        volumes = ["tmp/service.json:/local/service.json" ] #Mount the templated file into the container
        # run jq on file created by the template stanza
        # -e exits 0 if filter succedes. In this case "all service status is passing"
        args = ["-c", "jq </local/service.json -e '.[].Status|select(. == \"passing\")'"]
      }
```