### PR TITLE
Add conditional provisioning & test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,5 +18,5 @@ up:
 down:
 	vagrant destroy
 test:
-	ANSIBLE_ARGS='--extra-vars "mode=test"' vagrant up # --provision
+	ANSIBLE_ARGS='--extra-vars "mode=test"' vagrant up --provision
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ branch = $(shell git rev-parse --abbrev-ref HEAD)
 export SSL_CERT_FILE = /etc/ssl/certs/ca-certificates.crt
 export CURL_CA_BUNDLE = /etc/ssl/certs/ca-certificates.crt
 
-.ONESHELL .PHONY: build up
+.ONESHELL .PHONY: build up down test
 .DEFAULT_GOAL := build
 
 custom_ca:
@@ -17,4 +17,6 @@ up:
 	vagrant up
 down:
 	vagrant destroy
+test:
+	ANSIBLE_ARGS='--extra-vars "mode=test"' vagrant up # --provision
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,5 +15,13 @@ Vagrant.configure("2") do |config|
   end
   config.vm.provision "ansible_local" do |ansible|
       ansible.playbook = "./test/playbook.yml"
+
+      # default mode `dev`
+      ansible.extra_vars = {
+        mode: 'dev'
+      }
+
+      # use to override default mode (e.g. test mode)
+      ansible.raw_arguments = Shellwords.shellsplit(ENV['ANSIBLE_ARGS']) if ENV['ANSIBLE_ARGS']
   end
 end

--- a/test/playbook.yml
+++ b/test/playbook.yml
@@ -2,6 +2,7 @@
 - hosts: all
   become: yes
   tasks:
+    - debug: msg="{{ mode }} mode"
     - name: "wait for nomad to come up"
       uri:
         url: "http://127.0.0.1:4646/v1/jobs"
@@ -18,3 +19,8 @@
     - name: start hive nomad job
       command: nomad job run /vagrant/test/hive-connect.hcl
       register: fileoutput
+
+    - name: Test healthchecks of services
+      include_tasks: test.yml
+      # variable mode setup via extra_args in Vagrant.ansible_local or bash -> ANSIBLE_ARGS='--extra-vars "mode=test"' vagrant up --provision
+      when: mode == "test"

--- a/test/test.yml
+++ b/test/test.yml
@@ -2,7 +2,7 @@
 - name: Minio healthchecks pass
   uri:
     #    curl -G -v localhost:8500/v1/health/checks/minio --data-urlencode 'filter=(Status=="passing")'
-    url: http://localhost:8500/v1/health/checks/minio?filter=%28Status%3D%3D%22passing%22%29
+    url: http://localhost:8500/v1/health/checks/minio?filter={{ '(Status=="passing")' | urlencode }}
     method: GET
     return_content: yes
     status_code: 200
@@ -18,7 +18,7 @@
 - name: Hive-database healthchecks pass
   uri:
     #    curl -G -v localhost:8500/v1/health/checks/hive-database --data-urlencode 'filter=(Status=="passing")'
-    url: http://localhost:8500/v1/health/checks/hive-database?filter=%28Status%3D%3D%22passing%22%29
+    url: http://localhost:8500/v1/health/checks/hive-database?filter={{ '(Status=="passing")' | urlencode }}
     method: GET
     return_content: yes
     status_code: 200
@@ -33,7 +33,7 @@
 - name: Hive-metastore healthchecks pass
   uri:
     #    curl -G -v localhost:8500/v1/health/checks/hive-metastore --data-urlencode 'filter=(Status=="passing")'
-    url: http://localhost:8500/v1/health/checks/hive-metastore?filter=%28Status%3D%3D%22passing%22%29
+    url: http://localhost:8500/v1/health/checks/hive-metastore?filter={{ '(Status=="passing")' | urlencode }}
     method: GET
     return_content: yes
     status_code: 200
@@ -48,7 +48,7 @@
 - name: Hive-server healthchecks pass
   uri:
     #    curl -G -v localhost:8500/v1/health/checks/hive-server --data-urlencode 'filter=(Status=="passing")'
-    url: http://localhost:8500/v1/health/checks/hive-server?filter=%28Status%3D%3D%22passing%22%29
+    url: http://localhost:8500/v1/health/checks/hive-server?filter={{ '(Status=="passing")' | urlencode }}
     method: GET
     return_content: yes
     status_code: 200

--- a/test/test.yml
+++ b/test/test.yml
@@ -1,0 +1,61 @@
+# Minio group
+- name: Minio healthchecks pass
+  uri:
+    #    curl -G -v localhost:8500/v1/health/checks/minio --data-urlencode 'filter=(Status=="passing")'
+    url: http://localhost:8500/v1/health/checks/minio?filter=%28Status%3D%3D%22passing%22%29
+    method: GET
+    return_content: yes
+    status_code: 200
+    body_format: json
+  register: result_minio
+  retries: 15
+  delay: 15
+  until: result_minio.json | length == 2
+- name: Response body result_minio
+  debug: msg="Here {{ (result_minio.json) }}"
+
+#  Hive group
+- name: Hive-database healthchecks pass
+  uri:
+    #    curl -G -v localhost:8500/v1/health/checks/hive-database --data-urlencode 'filter=(Status=="passing")'
+    url: http://localhost:8500/v1/health/checks/hive-database?filter=%28Status%3D%3D%22passing%22%29
+    method: GET
+    return_content: yes
+    status_code: 200
+    body_format: json
+  register: result_hive_database
+  retries: 20
+  delay: 30
+  until: result_hive_database.json | length == 1
+- name: Response body result_hive_database
+  debug: msg="Here {{ (result_hive_database.json) }}"
+
+- name: Hive-metastore healthchecks pass
+  uri:
+    #    curl -G -v localhost:8500/v1/health/checks/hive-metastore --data-urlencode 'filter=(Status=="passing")'
+    url: http://localhost:8500/v1/health/checks/hive-metastore?filter=%28Status%3D%3D%22passing%22%29
+    method: GET
+    return_content: yes
+    status_code: 200
+    body_format: json
+  register: result_hive_metastore
+  retries: 30
+  delay: 30
+  until: result_hive_metastore.json | length == 1
+- name: Response body result_hive_metastore
+  debug: msg="Here {{ (result_hive_metastore.json) }}"
+
+- name: Hive-server healthchecks pass
+  uri:
+    #    curl -G -v localhost:8500/v1/health/checks/hive-server --data-urlencode 'filter=(Status=="passing")'
+    url: http://localhost:8500/v1/health/checks/hive-server?filter=%28Status%3D%3D%22passing%22%29
+    method: GET
+    return_content: yes
+    status_code: 200
+    body_format: json
+  register: result_hive_server
+  retries: 20
+  delay: 30
+  until: result_hive_server.json | length == 2
+- name: Response body result_hive_server
+  debug: msg="Here {{ (result_hive_server.json) }}"


### PR DESCRIPTION
Execute `make test`
## Logs
```
==> default: Running provisioner: ansible_local...
    default: Running ansible-playbook...

PLAY [all] *********************************************************************

TASK [Gathering Facts] *********************************************************
[DEPRECATION WARNING]: Distribution Ubuntu 18.04 on host default should use 
/usr/bin/python3, but is using /usr/bin/python for backward compatibility with 
prior Ansible releases. A future Ansible release will default to using the 
discovered platform python for this host. See https://docs.ansible.com/ansible/
2.9/reference_appendices/interpreter_discovery.html for more information. This 
feature will be removed in version 2.12. Deprecation warnings can be disabled 
by setting deprecation_warnings=False in ansible.cfg.
ok: [default]

TASK [debug] *******************************************************************
ok: [default] => {
    "msg": "test mode"
}

TASK [wait for nomad to come up] ***********************************************
ok: [default]

TASK [start minio nomad job] ***************************************************
changed: [default]

TASK [start hive nomad job] ****************************************************
changed: [default]

TASK [Test healthchecks of services] *******************************************
included: /vagrant/test/test.yml for default

TASK [Minio healthchecks pass] *************************************************
FAILED - RETRYING: Minio healthchecks pass (15 retries left).
FAILED - RETRYING: Minio healthchecks pass (14 retries left).
FAILED - RETRYING: Minio healthchecks pass (13 retries left).
FAILED - RETRYING: Minio healthchecks pass (12 retries left).
ok: [default]

TASK [Response body result_minio] **********************************************
ok: [default] => {
    "msg": "Here [{'Node': 'vagrant', 'CheckID': '_nomad-check-3fd73789f9c81c93ac440f1b6c354ac93bf63584', 'Name': 'minio-live', 'Definition': {}, 'Notes': '', 'ModifyIndex': 91, 'Status': 'passing', 'ServiceName': 'minio', 'ServiceID': '_nomad-task-0d6e48ec-93c0-c0eb-a74b-f5cdb64d7eba-group-s3-minio-9000', 'Output': 'HTTP GET http://10.0.3.10:24366/minio/health/live: 200 OK Output: ', 'ServiceTags': [], 'CreateIndex': 45, 'Type': 'http'}, {'Node': 'vagrant', 'CheckID': '_nomad-check-f64a9ab3a353d0cdea3f08fd041968d8a16bdffc', 'Name': 'minio-ready', 'Definition': {}, 'Notes': '', 'ModifyIndex': 92, 'Status': 'passing', 'ServiceName': 'minio', 'ServiceID': '_nomad-task-0d6e48ec-93c0-c0eb-a74b-f5cdb64d7eba-group-s3-minio-9000', 'Output': 'HTTP GET http://10.0.3.10:29433/minio/health/ready: 200 OK Output: ', 'ServiceTags': [], 'CreateIndex': 47, 'Type': 'http'}]"
}

TASK [Hive-database healthchecks pass] *****************************************
FAILED - RETRYING: Hive-database healthchecks pass (20 retries left).
ok: [default]

TASK [Response body result_hive_database] **************************************
ok: [default] => {
    "msg": "Here [{'Node': 'vagrant', 'CheckID': '_nomad-check-d5d5852d4d50552418c3e643d1f8f1c378870a45', 'Name': 'service: \"hive-database\" check', 'Definition': {}, 'Notes': '', 'ModifyIndex': 104, 'Status': 'passing', 'ServiceName': 'hive-database', 'ServiceID': '_nomad-task-3a5625f1-92bf-9f77-f4f5-3e58cc939b9c-group-database-hive-database-5432', 'Output': '/var/run/postgresql:5432 - accepting connections\\n', 'ServiceTags': [], 'CreateIndex': 59, 'Type': 'ttl'}]"
}

TASK [Hive-metastore healthchecks pass] ****************************************
FAILED - RETRYING: Hive-metastore healthchecks pass (30 retries left).
FAILED - RETRYING: Hive-metastore healthchecks pass (29 retries left).
FAILED - RETRYING: Hive-metastore healthchecks pass (28 retries left).
FAILED - RETRYING: Hive-metastore healthchecks pass (27 retries left).
FAILED - RETRYING: Hive-metastore healthchecks pass (26 retries left).
FAILED - RETRYING: Hive-metastore healthchecks pass (25 retries left).
FAILED - RETRYING: Hive-metastore healthchecks pass (24 retries left).
FAILED - RETRYING: Hive-metastore healthchecks pass (23 retries left).
FAILED - RETRYING: Hive-metastore healthchecks pass (22 retries left).
FAILED - RETRYING: Hive-metastore healthchecks pass (21 retries left).
FAILED - RETRYING: Hive-metastore healthchecks pass (20 retries left).
FAILED - RETRYING: Hive-metastore healthchecks pass (19 retries left).
FAILED - RETRYING: Hive-metastore healthchecks pass (18 retries left).
FAILED - RETRYING: Hive-metastore healthchecks pass (17 retries left).
FAILED - RETRYING: Hive-metastore healthchecks pass (16 retries left).
FAILED - RETRYING: Hive-metastore healthchecks pass (15 retries left).
ok: [default]

TASK [Response body result_hive_metastore] *************************************
ok: [default] => {
    "msg": "Here [{'Node': 'vagrant', 'CheckID': '_nomad-check-68b247b19d1e5d5c38ad1e29a3d84245ca2d4974', 'Name': 'beeline', 'Definition': {}, 'Notes': '', 'ModifyIndex': 317, 'Status': 'passing', 'ServiceName': 'hive-metastore', 'ServiceID': '_nomad-task-fc3b51b1-0785-5d0d-e2a7-40533ce9bdb6-group-metastore-hive-metastore-9083', 'Output': 'return code 0\\n', 'ServiceTags': [], 'CreateIndex': 289, 'Type': 'ttl'}]"
}

TASK [Hive-server healthchecks pass] *******************************************
FAILED - RETRYING: Hive-server healthchecks pass (20 retries left).
FAILED - RETRYING: Hive-server healthchecks pass (19 retries left).
ok: [default]

TASK [Response body result_hive_server] ****************************************
ok: [default] => {
    "msg": "Here [{'Node': 'vagrant', 'CheckID': '_nomad-check-55d46ae157c265bc18d90bc62cc33fde16bdc76c', 'Name': 'jmx', 'Definition': {}, 'Notes': '', 'ModifyIndex': 353, 'Status': 'passing', 'ServiceName': 'hive-server', 'ServiceID': '_nomad-task-64722ba8-fed6-7712-18f1-4b53ce32162b-group-server-hive-server-10000', 'Output': 'HTTP GET http://10.0.3.10:22254/jmx: 200 OK Output: _path_latency50thPercentileLatency\" : 0,\\n    \"S3guard_metadatastore_put_path_latency75thPercentileLatency\" : 0,\\n    \"S3guard_metadatastore_put_path_latency90thPercentileLatency\" : 0,\\n    \"S3guard_metadatastore_put_path_latency95thPercentileLatency\" : 0,\\n    \"S3guard_metadatastore_put_path_latency99thPercentileLatency\" : 0,\\n    \"S3guard_metadatastore_throttle_rateNumEvents\" : 0\\n  }, {\\n    \"name\" : \"org.apache.logging.log4j2:type=AsyncContext@4f4a7090,component=AsyncLoggerRingBuffer\",\\n    \"modelerType\" : \"org.apache.logging.log4j.core.jmx.RingBufferAdmin\",\\n    \"RemainingCapacity\" : 262144,\\n    \"BufferSize\" : 262144\\n  }, {\\n    \"name\" : \"org.apache.logging.log4j2:type=AsyncContext@4f4a7090\",\\n    \"modelerType\" : \"org.apache.logging.log4j.core.jmx.LoggerContextAdmin\",\\n    \"ObjectName\" : \"org.apache.logging.log4j2:type=AsyncContext@4f4a7090\",\\n    \"ConfigLocationUri\" : \"file:/opt/hive/conf/hive-log4j2.properties\",\\n    \"Status\" : \"STARTED\",\\n    \"ConfigText\" : \"# Licensed to the Apache Software Foundation (ASF) under one\\\\n# or more contributor license agreements.  See the NOTICE file\\\\n# distributed with this work for additional information\\\\n# regarding copyright ownership.  The ASF licenses this file\\\\n# to you under the Apache License, Version 2.0 (the\\\\n# \\\\\"License\\\\\"); you may not use this file except in compliance\\\\n# with the License.  You may obtain a copy of the License at\\\\n#\\\\n#     http://www.apache.org/licenses/LICENSE-2.0\\\\n#\\\\n# Unless required by applicable law or agreed to in writing, software\\\\n# distributed under the License is distributed on an \\\\\"AS IS\\\\\" BASIS,\\\\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\\\\n# See the License for the specific language governing permissions and\\\\n# limitations under the License.\\\\n\\\\nstatus = INFO\\\\nname = HiveLog4j2\\\\npackages = org.apache.hadoop.hive.ql.log\\\\n\\\\n# list of properties\\\\nproperty.hive.log.level = INFO\\\\nproperty.hive.root.logger = DRFA\\\\nproperty.hive.log.dir = ${sys:java.io.tmpdir}/${sys:user.name}\\\\nproperty.hive.log.file = hive.log\\\\n\\\\n# list of all appenders\\\\nappenders = console, DRFA\\\\n\\\\n# console appender\\\\nappender.console.type = Console\\\\nappender.console.name = console\\\\nappender.console.target = SYSTEM_ERR\\\\nappender.console.layout.type = PatternLayout\\\\nappender.console.layout.pattern = %d{yy/MM/dd HH:mm:ss} [%t]: %p %c{2}: %m%n\\\\n\\\\n# daily rolling file appender\\\\nappender.DRFA.type = RollingFile\\\\nappender.DRFA.name = DRFA\\\\nappender.DRFA.fileName = ${sys:hive.log.dir}/${sys:hive.log.file}\\\\n# Use %pid in the filePattern to append <process-id>@<host-name> to the filename if you want separate log files for different CLI session\\\\nappender.DRFA.filePattern = ${sys:hive.log.dir}/${sys:hive.log.file}.%d{yyyy-MM-dd}\\\\nappender.DRFA.layout.type = PatternLayout\\\\nappender.DRFA.layout.pattern = %d{ISO8601} %-5p [%t]: %c{2} (%F:%M(%L)) - %m%n\\\\nappender.DRFA.policies.type = Policies\\\\nappender.DRFA.policies.time.type = TimeBasedTriggeringPolicy\\\\nappender.DRFA.policies.time.interval = 1\\\\nappender.DRFA.policies.time.modulate = true\\\\nappender.DRFA.strategy.type = DefaultRolloverStrategy\\\\nappender.DRFA.strategy.max = 30\\\\n\\\\n# list of all loggers\\\\nloggers = NIOServerCnxn, ClientCnxnSocketNIO, DataNucleus, Datastore, JPOX\\\\n\\\\nlogger.NIOServerCnxn.name = org.apache.zookeeper.server.NIOServerCnxn\\\\nlogger.NIOServerCnxn.level = WARN\\\\n\\\\nlogger.ClientCnxnSocketNIO.name = org.apache.zookeeper.ClientCnxnSocketNIO\\\\nlogger.ClientCnxnSocketNIO.level = WARN\\\\n\\\\nlogger.DataNucleus.name = DataNucleus\\\\nlogger.DataNucleus.level = ERROR\\\\n\\\\nlogger.Datastore.name = Datastore\\\\nlogger.Datastore.level = ERROR\\\\n\\\\nlogger.JPOX.name = JPOX\\\\nlogger.JPOX.level = ERROR\\\\n\\\\n# root logger\\\\nrootLogger.level = ${sys:hive.log.level}\\\\nrootLogger.appenderRefs = root\\\\nrootLogger.appenderRef.root.ref = ${sys:hive.root.logger}\\\\n\",\\n    \"ConfigName\" : \"HiveLog4j2\",\\n    \"ConfigClassName\" : \"org.apache.logging.log4j.core.config.properties.PropertiesConfiguration\",\\n    \"ConfigFilter\" : \"null\",\\n    \"ConfigProperties\" : \"{hostName=4f38803be9bd, contextName=AsyncContext@4f4a7090}\",\\n    \"Name\" : \"AsyncContext@4f4a7090\"\\n  } ]\\n}', 'ServiceTags': [], 'CreateIndex': 230, 'Type': 'http'}, {'Node': 'vagrant', 'CheckID': '_nomad-check-bc9187762210357d47a67ebef971c1c796463600', 'Name': 'beeline', 'Definition': {}, 'Notes': '', 'ModifyIndex': 343, 'Status': 'passing', 'ServiceName': 'hive-server', 'ServiceID': '_nomad-task-64722ba8-fed6-7712-18f1-4b53ce32162b-group-server-hive-server-10000', 'Output': 'return code 0\\n', 'ServiceTags': [], 'CreateIndex': 232, 'Type': 'ttl'}]"
}

PLAY RECAP *********************************************************************
default                    : ok=14   changed=2    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```